### PR TITLE
chore: disable dependabot for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    open-pull-requests-limit: 0  # Package updates are disabled for now.
     schedule:
       interval: "monthly"
       day: "monday"
@@ -14,6 +15,7 @@ updates:
       include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 0  # Package updates are disabled for now.
     schedule:
       interval: "monthly"
       day: "monday"


### PR DESCRIPTION
This is only an example repository to demo an automated release process. We don't want to receive dependabot PRs for it at the moment as it's rather spammy and not useful right now.